### PR TITLE
Clarify ConsecutiveMapLootReductionRate semantics.

### DIFF
--- a/server/Config/Config.cs
+++ b/server/Config/Config.cs
@@ -38,7 +38,7 @@ public sealed class VagabondConfig
     public bool LimitTraderMailAccess { get; set; } = true;
     public bool EnableConsecutiveMapLootReduction { get; set; } = true;
     public double ConsecutiveMapLootRetentionRate { get; set; } = 0.5;
-    public double ConsecutiveMapLootReductionMin { get; set; } = 0.05;
+    public double ConsecutiveMapLootRetentionMin { get; set; } = 0.05;
     public double HealthOnDeath { get; set; }
 
     // internal

--- a/server/Config/Config.cs
+++ b/server/Config/Config.cs
@@ -37,7 +37,7 @@ public sealed class VagabondConfig
     public bool WipeStashOnFirstRaidEntry { get; set; } = true;
     public bool LimitTraderMailAccess { get; set; } = true;
     public bool EnableConsecutiveMapLootReduction { get; set; } = true;
-    public double ConsecutiveMapLootReductionRate { get; set; } = 0.5;
+    public double ConsecutiveMapLootRetentionRate { get; set; } = 0.5;
     public double ConsecutiveMapLootReductionMin { get; set; } = 0.05;
     public double HealthOnDeath { get; set; }
 

--- a/server/Config/vagabond.json
+++ b/server/Config/vagabond.json
@@ -88,9 +88,16 @@
   // This streak resets when you successfully extract from a different map. death/aborts do not change the streak.
   // factory day and night count as the same map.
   "EnableConsecutiveMapLootReduction": true,
-  // Loot multiplier. 0.5 = halving each repeated raid (1st=100%, 2nd=50%, 3rd=25%, etc)
+  // Exponential multiplier applied to loot per consecutive raid on the same map.
+  // lootMultiplier = ConsecutiveMapLootReductionRate ^ #consecutiveRaids
+  //
+  // This is a retention value, not a reduction percentage.
+  //
+  //  0.9 = keep 90% loot per raid. After 3 raids : 0.9 ^ 3 = 0.729% loot
+  //  0.5 = keep 50% loot per raid. After 3 raids : 0.5 ^ 3 = 0.125% loot
+  //  0.1 = keep 10% loot per raid. After 1 raid  : 0.1 ^ 1 = 10% loot
   "ConsecutiveMapLootReductionRate": 0.5,
-  // the minimum amount of loot regardless of streeak. 0.05 = 5% of the normal amount of loot.
+  // the minimum amount of loot regardless of streak. 0.05 = 5% of the normal amount of loot.
   "ConsecutiveMapLootReductionMin": 0.05,
   // if enabled, your limbs are healed to this amount when you die.
   // Examples:

--- a/server/Config/vagabond.json
+++ b/server/Config/vagabond.json
@@ -93,8 +93,8 @@
   //  0.5 = keep 50% loot per raid. After 2 raids, the loot spanws are reduced to: 25% (0.5 ^ 2 = 0.25)
   //  0.1 = keep 10% loot per raid. After 2 raids, the loot spanws are reduced to: 1% (0.1 ^ 2 = 0.01)
   "ConsecutiveMapLootRetentionRate": 0.5,
-  // the minimum amount of loot regardless of streak. 0.05 = 5% of the normal amount of loot.
-  "ConsecutiveMapLootReductionMin": 0.05,
+  // the minimum amount of loot spawn regardless of streak. 0.05 = 5% of the default/normal amount of loot.
+  "ConsecutiveMapLootRetentionMin": 0.05,
   // if enabled, your limbs are healed to this amount when you die.
   // Examples:
   // 1.0 = 100%

--- a/server/Config/vagabond.json
+++ b/server/Config/vagabond.json
@@ -88,15 +88,11 @@
   // This streak resets when you successfully extract from a different map. death/aborts do not change the streak.
   // factory day and night count as the same map.
   "EnableConsecutiveMapLootReduction": true,
-  // Exponential multiplier applied to loot per consecutive raid on the same map.
-  // lootMultiplier = ConsecutiveMapLootReductionRate ^ #consecutiveRaids
-  //
-  // This is a retention value, not a reduction percentage.
-  //
-  //  0.9 = keep 90% loot per raid. After 3 raids : 0.9 ^ 3 = 0.729% loot
-  //  0.5 = keep 50% loot per raid. After 3 raids : 0.5 ^ 3 = 0.125% loot
-  //  0.1 = keep 10% loot per raid. After 1 raid  : 0.1 ^ 1 = 10% loot
-  "ConsecutiveMapLootReductionRate": 0.5,
+  // Exponential multiplier applied to total loot spawns per consecutive raid on the same map.
+  //  0.9 = keep 90% loot per raid. After 2 raids, the loot spanws are reduced to: 81% (0.9 ^ 2 = 0.81)
+  //  0.5 = keep 50% loot per raid. After 2 raids, the loot spanws are reduced to: 25% (0.5 ^ 2 = 0.25)
+  //  0.1 = keep 10% loot per raid. After 2 raids, the loot spanws are reduced to: 1% (0.1 ^ 2 = 0.01)
+  "ConsecutiveMapLootRetentionRate": 0.5,
   // the minimum amount of loot regardless of streak. 0.05 = 5% of the normal amount of loot.
   "ConsecutiveMapLootReductionMin": 0.05,
   // if enabled, your limbs are healed to this amount when you die.

--- a/server/Services/LootStreakService.cs
+++ b/server/Services/LootStreakService.cs
@@ -40,7 +40,7 @@ public static class LootStreakService
             return 1.0;
         }
 
-        return Math.Max(VagabondConfig.Config.ConsecutiveMapLootReductionMin,
+        return Math.Max(VagabondConfig.Config.ConsecutiveMapLootRetentionMin,
             Math.Pow(VagabondConfig.Config.ConsecutiveMapLootRetentionRate, state.ConsecutiveExtractsSameMap));
     }
 

--- a/server/Services/LootStreakService.cs
+++ b/server/Services/LootStreakService.cs
@@ -41,7 +41,7 @@ public static class LootStreakService
         }
 
         return Math.Max(VagabondConfig.Config.ConsecutiveMapLootReductionMin,
-            Math.Pow(VagabondConfig.Config.ConsecutiveMapLootReductionRate, state.ConsecutiveExtractsSameMap));
+            Math.Pow(VagabondConfig.Config.ConsecutiveMapLootRetentionRate, state.ConsecutiveExtractsSameMap));
     }
 
     public static void HandleSuccessfulExtract(VagabondSessionState state, string location)


### PR DESCRIPTION
**What :**

Adds inline comments above ConsecutiveMapLootReductionRate explaining that the value is an exponential retention multiplier, not a linear reduction percentage by using concrete examples for 0.9, 0.5, and 0.1 so an user can see at a glance what the config will do.

No code or behavior changes.

**Why :**

ConsecutiveMapLootReductionRate reads like "the rate at which loot is reduced" which, in my opinion, suggests linear behavior. I hit this myself, played a few raids with two friends, set the rate to 0.1 expecting a 10% reduction, and we found no loot on our second raid on Ground Zero. I had to read LootStreakService.GetCurrentMultiplier() to figure out that the formula is 0.1 ^ streak.

**Suggestion :**

Renaming ConsecutiveMapLootReductionRate to something like ConsecutiveMapLootRetentionRate. Makes it intuitive that the higher the setting, the more loot you keep, and avoids the "reduction equals subtract this much". I would be happy to open a separate PR for the rename if you're open to it !